### PR TITLE
Fetching revamp

### DIFF
--- a/frontend/src/components/calendar/Calendar.svelte
+++ b/frontend/src/components/calendar/Calendar.svelte
@@ -50,10 +50,6 @@
     })()
   );
 
-  $effect(() => {
-    console.log(date);
-  })
-
   let showModal = $state(NoOp);
 
   let [days, amountOfRows, processedEvents] = $derived((() => {

--- a/frontend/src/components/calendar/CalendarEntry.svelte
+++ b/frontend/src/components/calendar/CalendarEntry.svelte
@@ -4,9 +4,10 @@
   import VisibilityToggle from "../interactive/VisibilityToggle.svelte";
 
   import { GetCalendarColor } from "$lib/common/colors";
-  import { faultyCalendars } from "$lib/client/repository";
+  import { faultyCalendars, loadingCalendars } from "$lib/client/repository";
   import { focusIndicator } from "$lib/client/decoration";
-  import { hiddenCalendars, isCalendarVisible, setCalendarVisibility } from "$lib/client/localStorage";
+  import { isCalendarVisible, setCalendarVisibility } from "$lib/client/localStorage";
+  import Spinner from "../decoration/Spinner.svelte";
 
   interface Props {
     calendar: CalendarModel;
@@ -20,6 +21,12 @@
   faultyCalendars.subscribe((faulty) => {
     hasErrored = faulty.has(calendar.id);
   });
+
+  let isLoading = $state(false);
+  loadingCalendars.subscribe((loading) => {
+    isLoading = loading.has(calendar.id);
+  });
+
 
   $effect(() => {
     if (calendar && calendar.id) setCalendarVisibility(calendar.id, calendarVisible);
@@ -77,6 +84,9 @@
     </button>
   </span>
   <span class="buttons">
+    {#if isLoading}
+      <Spinner/>
+    {/if}
     <VisibilityToggle bind:visible={calendarVisible}/>
     {#if hasErrored}
       <Tooltip msg="An error occurred trying to retrieve events from this calendar." error={true}/>

--- a/frontend/src/components/calendar/SourceEntry.svelte
+++ b/frontend/src/components/calendar/SourceEntry.svelte
@@ -2,7 +2,7 @@
   import CollapseToggle from "../interactive/CollapseToggle.svelte";
   import Tooltip from "../interactive/Tooltip.svelte";
 
-  import { calendars, faultySources, fetchSourceCalendars } from "$lib/client/repository";
+  import { calendars, faultySources } from "$lib/client/repository";
   import { collapsedSources, setSourceCollapse } from "$lib/client/localStorage";
   import { focusIndicator } from "$lib/client/decoration";
 
@@ -22,8 +22,14 @@
   });
 
   let hasCals = $state(false);
-  calendars.subscribe(async () => {
-    hasCals = (await fetchSourceCalendars(source.id)).length > 0;
+  calendars.subscribe(async (cals) => {
+    hasCals = false;
+    for (const cal of cals) {
+      if (cal.source === source.id) {
+        hasCals = true;
+        break;
+      }
+    }
   })
 
   let showModal: ((source: SourceModel) => Promise<SourceModel>) = getContext("showSourceModal");

--- a/frontend/src/components/calendar/SourceEntry.svelte
+++ b/frontend/src/components/calendar/SourceEntry.svelte
@@ -2,11 +2,12 @@
   import CollapseToggle from "../interactive/CollapseToggle.svelte";
   import Tooltip from "../interactive/Tooltip.svelte";
 
-  import { calendars, faultySources } from "$lib/client/repository";
+  import { calendars, faultySources, loadingSources } from "$lib/client/repository";
   import { collapsedSources, setSourceCollapse } from "$lib/client/localStorage";
   import { focusIndicator } from "$lib/client/decoration";
 
   import { getContext } from "svelte";
+  import Spinner from "../decoration/Spinner.svelte";
 
   interface Props {
     source: SourceModel;
@@ -19,6 +20,11 @@
   let hasErrored = $state(false);
   faultySources.subscribe((faulty) => {
     hasErrored = faulty.has(source.id);
+  });
+
+  let isLoading = $state(false);
+  loadingSources.subscribe((loading) => {
+    isLoading = loading.has(source.id);
   });
 
   let hasCals = $state(false);
@@ -92,6 +98,9 @@
     {source.name}
   </button>
   <span>
+    {#if isLoading}
+      <Spinner/>
+    {/if}
     {#if hasCals}
       <CollapseToggle bind:collapsed={source.collapsed}/>
     {/if}

--- a/frontend/src/components/calendar/SourceEntry.svelte
+++ b/frontend/src/components/calendar/SourceEntry.svelte
@@ -24,6 +24,7 @@
   let hasCals = $state(false);
   calendars.subscribe(async (cals) => {
     hasCals = false;
+    if (!source) return;
     for (const cal of cals) {
       if (cal.source === source.id) {
         hasCals = true;
@@ -41,6 +42,7 @@
     if (source.id) setSourceCollapse(source.id, source.collapsed);
   })
   collapsedSources.subscribe((collapsed) => {
+    if (!source) return;
     source.collapsed = collapsed.has(source.id);
   });
 </script>

--- a/frontend/src/components/decoration/Spinner.svelte
+++ b/frontend/src/components/decoration/Spinner.svelte
@@ -1,0 +1,30 @@
+<style lang="scss">
+    @import "../../styles/animations.scss";
+
+    .wrapper {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100%;
+        animation: spinner $animationSpeedSlow linear infinite;
+    }
+
+    @keyframes spinner {
+        0% {
+            transform: rotate(0deg);
+        }
+        100% {
+            transform: rotate(360deg);
+        }
+    }
+</style>
+
+<script lang="ts">
+  import { LoaderCircle, Loader, RefreshCw } from "lucide-svelte";
+</script>
+
+<span class="wrapper">
+    <LoaderCircle size={16}/>
+    <!--<Loader/>-->
+    <!--<RefreshCw/>-->
+</span>

--- a/frontend/src/components/decoration/Spinner.svelte
+++ b/frontend/src/components/decoration/Spinner.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+  import { LoaderCircle } from "lucide-svelte";
+</script>
+
 <style lang="scss">
     @import "../../styles/animations.scss";
 
@@ -6,22 +10,9 @@
         justify-content: center;
         align-items: center;
         height: 100%;
-        animation: spinner $animationSpeedSlow linear infinite;
-    }
-
-    @keyframes spinner {
-        0% {
-            transform: rotate(0deg);
-        }
-        100% {
-            transform: rotate(360deg);
-        }
+        animation: spin $animationSpeedSlow linear infinite;
     }
 </style>
-
-<script lang="ts">
-  import { LoaderCircle, Loader, RefreshCw } from "lucide-svelte";
-</script>
 
 <span class="wrapper">
     <LoaderCircle size={16}/>

--- a/frontend/src/components/layout/Horizontal.svelte
+++ b/frontend/src/components/layout/Horizontal.svelte
@@ -3,11 +3,13 @@
 
   interface Props {
     position?: "left" | "center" | "right" | "justify";
+    width?: "full" | "auto";
     children?: Snippet;
   }
 
   let {
     position = "justify",
+    width = "full",
     children
   }: Props = $props();
 </script>
@@ -17,10 +19,13 @@
 
   div {
     display: flex;
-    width: 100%;
     flex-direction: row;
     flex-wrap: nowrap;
     gap: $gapSmall;
+  }
+
+  div.full {
+    width: 100%;
   }
 
   div.justify {
@@ -51,6 +56,7 @@
   class:left={position == "left"}
   class:right={position == "right"}
   class:center={position == "center"}
+  class:full={width == "full"}
 >
   {@render children?.()}
 </div>

--- a/frontend/src/components/modals/EventModal.svelte
+++ b/frontend/src/components/modals/EventModal.svelte
@@ -7,7 +7,7 @@
   import TextInput from "../forms/TextInput.svelte";
 
   import { EmptyEvent } from "$lib/client/placeholders";
-  import { createEvent, deleteEvent, editEvent, getCalendars } from "$lib/client/repository";
+  import { createEvent, deleteEvent, editEvent, getAllCalendars } from "$lib/client/repository";
 
   interface Props {
     showCreateModal?: (date: Date) => Promise<EventModel>;
@@ -25,7 +25,7 @@
   let saveEvent = (_: EventModel | PromiseLike<EventModel>) => {};
   let cancelEvent = (_?: any) => {};
 
-  showCreateModal = (date: Date) => {
+  showCreateModal = async (date: Date) => {
     cancelEvent();
     
     editMode = false;
@@ -49,7 +49,7 @@
       }
     };
 
-    currentCalendars = getCalendars();
+    currentCalendars = await getAllCalendars();
     setTimeout(showCreateModalInternal, 0);
 
     return new Promise((resolve, reject) => {

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -515,8 +515,6 @@ export async function getAllEvents(start: Date, end: Date, forceRefresh = false)
   start.setMonth(start.getMonth() - 1);
   end.setMonth(end.getMonth() + 1);
 
-  console.log(start.toISOString(), end.toISOString());
-
   compileEvents(start, end);
   const allSources = await getSources(forceRefresh);
   const events = await atLeastOnePromise(allSources.map((source) => getEventsFromSource(source.id, start, end, forceRefresh)));
@@ -540,7 +538,6 @@ async function getEventsFromCalendar(calendar: string, start: Date, end: Date, f
 
   while (fetchStart.getTime() <= fetchEnd.getTime()) {
     const cached = cacheOk(cache.get(fetchStart.getTime()));
-    console.log(cache.get(fetchStart.getTime()))
     if (!cached) break;
     result = result.concat(cached.map((id) => eventsMap.get(id)).filter((event) => event != null));
     fetchStart.setMonth(fetchStart.getMonth() + 1);
@@ -548,14 +545,12 @@ async function getEventsFromCalendar(calendar: string, start: Date, end: Date, f
 
   while (fetchEnd.getTime() >= fetchStart.getTime()) {
     const cached = cacheOk(cache.get(fetchEnd.getTime()));
-    console.log(cache.get(fetchEnd.getTime()))
     if (!cached) break;
     result = result.concat(cached.map((id) => eventsMap.get(id)).filter((event) => event != null));
     fetchEnd.setMonth(fetchEnd.getMonth() - 1);
   }
 
   if (fetchStart.getTime() > fetchEnd.getTime()) {
-    console.log("nothing to load")
     return result;
   }
 

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -28,13 +28,6 @@ export const faultyCalendars = writable(new Set<string>());
 export const loadingSources = writable(new Set<string>());
 export const loadingCalendars = writable(new Set<string>());
 
-loadingSources.subscribe((x) => {
-  console.log("Loading sources", Array.from(x.entries()));
-});
-loadingCalendars.subscribe((x) => {
-  console.log("Loading calendars", Array.from(x.entries()));
-});
-
 //
 // Caching
 //

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -585,7 +585,12 @@ async function getEventsFromCalendar(calendar: string, start: Date, end: Date, f
 }
 
 async function fetchEvents(calendar: string, start: Date, end: Date): Promise<EventModel[]> {
-  const fetched: EventModel[] = (await fetchJson(`/api/calendars/${calendar}/events?start=${encodeURIComponent(start.toISOString())}&end=${encodeURIComponent(end.toISOString())}`)).events;
+  const localStart = new Date(start);
+  localStart.setHours(0, 0, 0, 0);
+  const localEnd = new Date(end);
+  localEnd.setHours(23, 59, 59, 999);
+
+  const fetched: EventModel[] = (await fetchJson(`/api/calendars/${calendar}/events?start=${encodeURIComponent(localStart.toISOString())}&end=${encodeURIComponent(localEnd.toISOString())}`)).events;
 
   let calendarEventsCache = eventsCache.get(calendar);
   if (!calendarEventsCache) {

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -287,6 +287,7 @@ export const createSource = async (newSource: SourceModel): Promise<void> => {
   });
 
   newSource.id = json.id;
+  sourcesCache.value = sourcesCache.value?.concat(newSource) || [ newSource ];
   sources.update((sources) => sources.concat(newSource));
 
   getCalendars(newSource.id).then((cals) => {
@@ -311,7 +312,7 @@ export const editSource = async (modifiedSource: SourceModel): Promise<void> => 
     throw err;
   });
   
-  sourcesCache.value = sourcesCache.value?.map((source => source.id === modifiedSource.id ? modifiedSource : source)) || [];
+  sourcesCache.value = sourcesCache.value?.map((source => source.id === modifiedSource.id ? modifiedSource : source)) || [ modifiedSource ];
   compileSources();
 
   getCalendars(modifiedSource.id).then((cals) => {

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -5,6 +5,7 @@ import { writable } from "svelte/store";
 
 import { hiddenCalendars, isCalendarVisible } from "./localStorage";
 import { queueNotification } from "./notifications";
+import { NoOp } from "./placeholders";
 
 //
 // Constants
@@ -63,7 +64,7 @@ async function fetchResponse(url: string, options: RequestInit = {}) {
 }
 
 async function fetchJson(url: string, options: RequestInit = {}) {
-  return (await fetchResponse(url, options)).json();
+  return (await fetchResponse(url, options).catch(err => { throw err; })).json();
 }
 
 //
@@ -292,9 +293,9 @@ export const createSource = async (newSource: SourceModel): Promise<void> => {
 
   getCalendars(newSource.id).then((cals) => {
     cals.forEach((cal) => {
-      getEventsFromCalendar(cal.id, eventsRangeStart, eventsRangeEnd);
+      getEventsFromCalendar(cal.id, eventsRangeStart, eventsRangeEnd).catch(NoOp);
     });
-  });
+  }).catch(NoOp);
 
   saveCache();
 }

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -1,80 +1,73 @@
+import { atLeastOnePromise } from "$lib/common/misc";
+import { browser } from "$app/environment";
+
 import { writable } from "svelte/store";
 
-import { hiddenCalendars } from "./localStorage";
-import { isCalendarVisible, isSourceCollapsed } from "./localStorage";
+import { hiddenCalendars, isCalendarVisible } from "./localStorage";
 import { queueNotification } from "./notifications";
 
-// TODO: local storage integration for PWA offline support (longterm goal)
+//
+// Constants
+//
+
+const spoolerDelay = 50; // 50ms
+const maxCacheAge = 1000 * 60 * 10; // 10 minutes
+
+//
+// Subscribeable Stores
+//
 
 export const sources = writable([] as SourceModel[]);
 export const calendars = writable([] as CalendarModel[]);
 export const events = writable([] as EventModel[]);
 
-let sourceCalendars = new Map<string, Set<CalendarModel>>();
-let calendarEvents = new Map<string, Set<EventModel>>();
-
-let calendarMap = new Map<string, CalendarModel>();
-let eventsMap = new Map<string, EventModel>();
-
 export const faultySources = writable(new Set<string>());
 export const faultyCalendars = writable(new Set<string>());
 
-// TODO: this will depend on the month that the user is currently viewing (stored in session storaage)
-let lastStart = new Date();
-lastStart.setMonth(lastStart.getMonth() - 1);
-lastStart.setDate(0);
-let lastEnd = new Date();
-lastEnd.setMonth(lastEnd.getMonth() + 2);
-lastEnd.setDate(0);
+//
+// Caching
+//
 
-function allEvents(): EventModel[] {
-  const allEvents = Array.from(
-    calendarEvents
-      .entries()
-      .filter(x => isCalendarVisible(x[0]))
-      .map(x => Array.from(x[1])
-    )
-  ).flat();
-  eventsMap = new Map(allEvents.map(event => [event.id, event]));
-  return allEvents;
+let eventsRangeStart: Date = new Date();
+let eventsRangeEnd: Date = new Date();
+
+const emptyCache = { date: new Date(0), value: null };
+
+const sourcesCache: CacheEntry<SourceModel[]> = emptyCache; // sources
+const sourceDetailsCache: Map<string, CacheEntry<SourceModel>> = new Map(); // source -> details
+const calendarsCache: Map<string, CacheEntry<CalendarModel[]>> = new Map(); // source -> calendars
+const eventsCache: Map<string, Map<number, CacheEntry<string[]>>> = new Map(); // calendar -> month -> event id
+const eventsMap: Map<string, EventModel> = new Map(); // event id -> event
+
+function cacheOk<T>(cache: CacheEntry<T> | undefined): (T | null) {
+  const cacheResult = (cache && Date.now() - cache.date.getTime() < maxCacheAge) ? cache.value : null;
+  return (cache && Date.now() - cache.date.getTime() < maxCacheAge) ? cache.value : null;
 }
 
-function allCalendars(): CalendarModel[] {
-  const allCalendars = Array.from(sourceCalendars.values().map(x => Array.from(x))).flat();
-  calendarMap = new Map(allCalendars.map(calendar => [calendar.id, calendar]));
-  return allCalendars;
-}
+// 
+// Web
+// 
 
-function compileEvents() {
-  events.set(allEvents());
-}
-
-function compileCalendars() {
-  calendars.set(allCalendars());
-}
-
-export const fetchSources = async (): Promise<void> => {
-  const response = await fetch("/api/sources");
+async function fetchResponse(url: string, options: RequestInit = {}) {
+  const response = await fetch(url, options)
+    .catch((err) => {
+      throw new Error("Could not contact the server");
+    });
   if (response.ok) {
-    const fetchedSources = await response.json() as SourceModel[];
-
-    for (const source of fetchedSources) {
-      source.collapsed = isSourceCollapsed(source.id);
-
-      fetchCalendars(source.id).catch(err => {
-        queueNotification(
-          "failure",
-          `Failed to fetch calendars from source "${source.name}":\n${err.message}`
-        );
-      });
-    }
-
-    sources.set(fetchedSources);
+    return response;
   } else {
     const json = await response.json();
     throw new Error(json ? json.error : "Could not contact the server");
   }
-};
+}
+
+async function fetchJson(url: string, options: RequestInit = {}) {
+  return (await fetchResponse(url, options)).json();
+}
+
+//
+// Form Data
+//
 
 function getSourceFormData(source: SourceModel): FormData {
   const formData = new FormData();
@@ -104,145 +97,6 @@ function getSourceFormData(source: SourceModel): FormData {
   return formData;
 }
 
-export const createSource = async (newSource: SourceModel): Promise<void> => {
-  let formData: FormData;
-  try {
-    formData = getSourceFormData(newSource);
-  } catch (e: any) {
-    throw e;
-  }
-
-  const response = await fetch(`/api/sources`, { method: "PUT", body: formData });
-  if (response.ok) {
-    const json = await response.json();
-    newSource.id = json.id;
-    sources.update((sources) => sources.concat(newSource));
-
-    fetchCalendars(newSource.id).catch(err => {
-      queueNotification(
-        "failure",
-        `Failed to fetch calendar: ${err.message}`
-      );
-    });
-  } else {
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
-}
-
-export const editSource = async (modifiedSource: SourceModel): Promise<void> => {
-  let formData = getSourceFormData(modifiedSource);
-
-  const response = await fetch(`/api/sources/${modifiedSource.id}`, { method: "PATCH", body: formData });
-  if (response.ok) {
-    sources.update((sources) => sources.map((source => source.id === modifiedSource.id ? modifiedSource : source)))
-
-    fetchCalendars(modifiedSource.id).catch(err => {
-      queueNotification(
-        "failure",
-        `Failed to fetch calendar: ${err.message}`
-      );
-    });
-  } else {
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
-}
-
-export const deleteSource = async (id: string): Promise<void> => {
-  const response = await fetch(`/api/sources/${id}`, { method: "DELETE" });
-  if (response.ok) {
-    sources.update((sources) => sources.filter((source) => source.id !== id));
-    sourceCalendars.get(id)?.forEach((calendar) => {
-      calendarEvents.delete(calendar.id);
-    });
-    sourceCalendars.delete(id);
-    compileEvents();
-  } else {
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
-}
-
-export const fetchCalendars = async (id: string): Promise<void> => {
-  const response = await fetch(`/api/sources/${id}/calendars`);
-  if (response.ok) {
-    faultySources.update((faultySources) => new Set([...faultySources].filter((faultySource) => faultySource !== id)));
-    const json = await response.json() as {calendars: CalendarModel[]};
-    const fetchCalendars = json.calendars;
-
-    for (const calendar of fetchCalendars) {
-      //calendar.visible = isCalendarVisible(calendar.id);
-
-      fetchEvents(calendar.id, lastStart, lastEnd).catch(err => {
-        queueNotification(
-          "failure",
-          `Failed to fetch events: ${err.message}`
-        );
-      });
-    }
-
-    sourceCalendars.set(id, new Set(fetchCalendars));
-    compileCalendars();
-  } else {
-    faultySources.update((faultySources) => new Set(faultySources.add(id)));
-    sourceCalendars.delete(id);
-    compileCalendars();
-
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
-};
-
-export const getCalendars = () => allCalendars();
-
-export const fetchAllEvents = async (start: Date, end: Date) => {
-  lastStart = start;
-  lastEnd = end;
-  for (const calendar of allCalendars()) {
-    fetchEvents(calendar.id, start, end).catch(err => {
-      queueNotification(
-        "failure",
-        `Failed to fetch events: ${err.message}`
-      );
-    });
-  }
-}
-
-export const fetchSourceCalendars = async (id: string) => {
-  return Array.from(sourceCalendars.get(id) || new Set<CalendarModel>());
-}
-
-export const fetchEvents = async (id: string, start: Date, end: Date): Promise<void> => {
-  const url = `/api/calendars/${id}/events?start=${encodeURIComponent(start.toISOString())}&end=${encodeURIComponent(end.toISOString())}`
-  const response = await fetch(url);
-  if (response.ok) {
-    faultyCalendars.update((faultyCalendars) => new Set([...faultyCalendars].filter((faultyCalendar) => faultyCalendar !== id)));
-    const json = await response.json() as {events: EventModel[]};
-    for (const event of json.events) {
-      event.date.start = new Date(event.date.start);
-      event.date.end = new Date(event.date.end);
-
-      if (event.date.allDay) {
-        event.date.start.setHours(0, 0, 0, 0);
-        event.date.end.setHours(0, 0, 0, 0);
-      }
-    }
-
-    // Do not remove events outside the requested range
-    const oldEvents = Array.from(calendarEvents.get(id) || new Set<EventModel>()).filter((event) => event.date.end < start || event.date.start > end);
-    calendarEvents.set(id, new Set(json.events.concat(oldEvents)));
-    compileEvents();
-  } else {
-    faultyCalendars.update((faultyCalendars) => new Set(faultyCalendars.add(id)));
-    calendarEvents.delete(id);
-    compileEvents();
-
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
-};
-
 function getEventFormData(event: EventModel): FormData {
   const formData = new FormData();
   formData.set("name", event.name);
@@ -265,7 +119,375 @@ function getEventFormData(event: EventModel): FormData {
   return formData;
 }
 
+//
+// Visibility
+//
+
+let compileCalendarsTimeout: ReturnType<typeof setTimeout>;
+function compileCalendars() {
+  clearTimeout(compileCalendarsTimeout);
+  compileCalendarsTimeout = setTimeout(() => {
+    const allCalendars = Array.from(calendarsCache.values().map(x => x.value).filter(x => x != null)).flat();
+    calendars.set(allCalendars);
+  }, spoolerDelay)
+}
+
+let compileEventsTimeout: ReturnType<typeof setTimeout>;
+function compileEvents(start: Date, end: Date) {
+  eventsRangeStart = start;
+  eventsRangeEnd = end;
+  clearTimeout(compileEventsTimeout);
+
+  compileEventsTimeout = setTimeout(() => {
+    const allEvents = 
+      Array.from(eventsCache.entries())
+      .filter(x => isCalendarVisible(x[0]) && x[1] != null) // Event must be visible
+      .map(x => Array.from(x[1].entries()))
+      .flat()
+      .filter(x => x[1] != null && x[0] >= start.getTime() && x[0] <= end.getTime()) // Event must be in the time frame
+      .map(x => x[1].value)
+      .filter(x => x != null) // Event must exist
+      .flat();
+    
+    const uniqueEvents = [ ...new Set(allEvents) ];
+
+    const eventsWithData = uniqueEvents.map((event) => eventsMap.get(event)).filter((event) => event != null);
+
+    events.set(eventsWithData);
+  }, spoolerDelay)
+}
+
+// 
+// Sources
+// 
+
+export async function getSources(forceRefresh = false): Promise<SourceModel[]> {
+  if (!browser) return [];
+
+  if (!forceRefresh) {
+    const cached = cacheOk(sourcesCache);
+    if (cached) return Promise.resolve(cached);
+  }
+
+  const fetchedSources = await fetchJson("/api/sources").catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to fetch sources: ${err.message}`
+    );
+    throw err;
+  });
+
+  sourcesCache.date = new Date();
+  sourcesCache.value = fetchedSources;
+  sources.set(fetchedSources);
+  return fetchedSources;
+}
+
+export async function getSourceDetails(id: string, forceRefresh = false): Promise<SourceModel> {
+  if (!browser) return {} as SourceModel;
+
+  if (!forceRefresh) {
+    const cached = cacheOk(sourceDetailsCache.get(id));
+    if (cached) return Promise.resolve(cached);
+  }
+
+  const fetched = await fetchJson(`/api/sources/${id}`).catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to fetch source details: ${err.message}`
+    );
+    throw err;
+  });
+
+  sourceDetailsCache.set(id, {
+    date: new Date(),
+    value: fetched
+  });
+  return fetched;
+}
+
+export const createSource = async (newSource: SourceModel): Promise<void> => {
+  if (!browser) return;
+
+  const formData = getSourceFormData(newSource);
+
+  const json = await fetchJson(`/api/sources`, { method: "PUT", body: formData }).catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to create source: ${err.message}`
+    );
+    throw err;
+  });
+
+  newSource.id = json.id;
+  sources.update((sources) => sources.concat(newSource));
+
+  getCalendars(newSource.id).then((cals) => {
+    cals.forEach((cal) => {
+      getEventsFromCalendar(cal.id, eventsRangeStart, eventsRangeEnd);
+    });
+  });
+}
+
+export const editSource = async (modifiedSource: SourceModel): Promise<void> => {
+  if (!browser) return;
+
+  let formData = getSourceFormData(modifiedSource);
+
+  await fetchResponse(`/api/sources/${modifiedSource.id}`, { method: "PATCH", body: formData }).catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to edit source: ${err.message}`
+    );
+    throw err;
+  });
+  
+  sourcesCache.value = sourcesCache.value?.map((source => source.id === modifiedSource.id ? modifiedSource : source)) || [];
+  sources.set(sourcesCache.value);
+
+  getCalendars(modifiedSource.id).then((cals) => {
+    cals.forEach((cal) => {
+      getEventsFromCalendar(cal.id, eventsRangeStart, eventsRangeEnd);
+    });
+  });
+}
+
+export const deleteSource = async (id: string): Promise<void> => {
+  if (!browser) return;
+
+  await fetchResponse(`/api/sources/${id}`, { method: "DELETE" }).catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to delete source: ${err.message}`
+    );
+    throw err;
+  });
+
+  sourcesCache.value = sourcesCache.value?.filter((source) => source.id !== id) || [];
+  sources.set(sourcesCache.value);
+
+  for (const calendar of calendarsCache.get(id)?.value || []) eventsCache.delete(calendar.id);
+
+  compileCalendars();
+  compileEvents(eventsRangeStart, eventsRangeEnd);
+}
+
+//
+// Calendars
+//
+
+export async function getAllCalendars(forceRefresh = false): Promise<CalendarModel[]> {
+  if (!browser) return [];
+
+  const allSources = await getSources(forceRefresh);
+
+  const calendars = await atLeastOnePromise(allSources.map((source) => getCalendars(source.id, forceRefresh)))
+
+  return calendars.flat();
+}
+
+async function getCalendars(id: string, forceRefresh = false): Promise<CalendarModel[]> {
+  if (!browser) return [];
+
+  if (!forceRefresh) {
+    const cached = cacheOk(calendarsCache.get(id));
+    if (cached) return Promise.resolve(cached);
+  }
+
+  const response = await fetchJson(`/api/sources/${id}/calendars`).catch((err) => {
+    faultySources.update((faulty) => {
+      faulty.add(id);
+      return faulty;
+    });
+
+    queueNotification(
+      "failure",
+      `Failed to fetch calendars: ${err.message}`
+    );
+    throw err;
+  });
+
+  faultySources.update((faulty) => {
+    faulty.delete(id);
+    return faulty;
+  });
+
+  const fetched: CalendarModel[] = response.calendars;
+
+  // Delete orphans
+  let anyOrphaned = false;
+  const fetchedSet = new Set(fetched.map(x => x.id));
+  for (const calendar of calendarsCache.get(id)?.value || []) {
+    if (!fetchedSet.has(calendar.id)) {
+      eventsCache.delete(calendar.id);
+      anyOrphaned = true;
+    }
+  }
+  
+  calendarsCache.set(id, {
+    date: new Date(),
+    value: fetched
+  });
+
+  compileCalendars();
+  if (anyOrphaned) compileEvents(eventsRangeStart, eventsRangeEnd);
+  return fetched;
+}
+
+hiddenCalendars.subscribe(() => {
+  compileEvents(eventsRangeStart, eventsRangeEnd);
+});
+
+//
+// Events
+//
+
+function determineEventMonths(event: EventModel): Date[] {
+  const start = new Date(event.date.start);
+  start.setDate(1);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(event.date.end);
+
+  const months = [start];
+  while (start < end) {
+    start.setMonth(start.getMonth() + 1);
+    months.push(new Date(start));
+  }
+
+  return months;
+}
+
+function addEventToCache(event: EventModel, date: Date) {
+  let calendarEventsCache = eventsCache.get(event.calendar);
+  if (!calendarEventsCache) {
+    calendarEventsCache = new Map();
+    eventsCache.set(event.calendar, calendarEventsCache);
+  }
+
+  let cacheEntry = calendarEventsCache.get(date.getTime());
+  if (!cacheEntry) {
+    cacheEntry = { date: new Date(), value: [] };
+    calendarEventsCache.set(date.getTime(), cacheEntry);
+  }
+
+  calendarEventsCache.set(date.getTime(), {
+    date: cacheEntry.date,
+    value: [ ...cacheEntry.value || [], event.id ]
+  });
+}
+
+function removeEventFromCache(event: EventModel, date: Date) {
+  if (!eventsCache.has(event.calendar)) return;
+  const cacheEntry = eventsCache.get(event.calendar)?.get(date.getTime());
+  if (!cacheEntry || !cacheEntry.value) return;
+  cacheEntry.value = cacheEntry.value.filter((id) => id !== event.id);
+}
+
+export async function getAllEvents(start: Date, end: Date, forceRefresh = false): Promise<EventModel[]> {
+  if (!browser) return [];
+
+  // Set start and end to the start and end of each month
+  start.setDate(1);
+  end.setMonth(end.getMonth() + 1);
+  end.setDate(0);
+
+  // Add one month of padding in both directions
+  start.setMonth(start.getMonth() - 1);
+  end.setMonth(end.getMonth() + 1);
+
+  if (!forceRefresh) compileEvents(start, end);
+  const allSources = await getSources();
+  const events = await atLeastOnePromise(allSources.map((source) => getEventsFromSource(source.id, start, end)));
+  compileEvents(start, end);
+  return events.flat();
+}
+
+async function getEventsFromSource(source: string, start: Date, end: Date, forceRefresh = false): Promise<EventModel[]> {
+  const calendars = await getCalendars(source, forceRefresh);
+  const events = await atLeastOnePromise(calendars.map((calendar) => getEventsFromCalendar(calendar.id, start, end, forceRefresh)));
+  return events.flat();
+}
+
+async function getEventsFromCalendar(calendar: string, start: Date, end: Date, forceRefresh = false): Promise<EventModel[]> {
+  let result: EventModel[] = [];
+
+  const cache = (forceRefresh ? null : eventsCache.get(calendar)) || new Map<number, CacheEntry<string[]>>();
+
+  // Limit the range we need to ask for but only use one request per calendar
+  const fetchStart = new Date(start);
+  const fetchEnd = new Date(end);
+
+  while (fetchStart.getTime() <= fetchEnd.getTime()) {
+    const cached = cacheOk(cache.get(fetchStart.getTime()));
+    if (!cached) break;
+    result = result.concat(cached.map((id) => eventsMap.get(id)).filter((event) => event != null));
+    fetchStart.setMonth(fetchStart.getMonth() + 1);
+  }
+
+  while (fetchEnd.getTime() >= fetchStart.getTime()) {
+    const cached = cacheOk(cache.get(fetchEnd.getTime()));
+    if (!cached) break;
+    result = result.concat(cached.map((id) => eventsMap.get(id)).filter((event) => event != null));
+    fetchEnd.setMonth(fetchEnd.getMonth() - 1);
+  }
+
+  if (fetchStart.getTime() > fetchEnd.getTime()) {
+    return result;
+  }
+
+  const fetchedEvents = await fetchEvents(calendar, start, end).catch((err) => {
+    faultyCalendars.update((faulty) => {
+      faulty.add(calendar);
+      return faulty;
+    });
+
+    queueNotification(
+      "failure",
+      `Failed to fetch events: ${err.message}`
+    );
+    throw err;
+  });
+
+  return result.concat(fetchedEvents);
+}
+
+async function fetchEvents(calendar: string, start: Date, end: Date): Promise<EventModel[]> {
+  const fetched: EventModel[] = (await fetchJson(`/api/calendars/${calendar}/events?start=${encodeURIComponent(start.toISOString())}&end=${encodeURIComponent(end.toISOString())}`)).events;
+
+  let calendarEventsCache = eventsCache.get(calendar);
+  if (!calendarEventsCache) {
+    calendarEventsCache = new Map();
+    eventsCache.set(calendar, calendarEventsCache);
+  }
+  for (let i = new Date(start); i.getTime() < end.getTime(); i.setMonth(i.getMonth() + 1)) {
+    calendarEventsCache.set(i.getTime(), {
+      date: new Date(),
+      value: []
+    });
+  }
+
+  for (const event of fetched) {
+    event.date.start = new Date(event.date.start);
+    event.date.end = new Date(event.date.end);
+
+    if (event.date.allDay) {
+      event.date.start.setHours(0, 0, 0, 0);
+      event.date.end.setHours(0, 0, 0, 0);
+    }
+
+    eventsMap.set(event.id, event);
+    for (const month of determineEventMonths(event)) {
+      addEventToCache(event, month);
+    }
+  }
+
+  return fetched;
+}
+
 export const createEvent = async (newEvent: EventModel): Promise<void> => {
+  if (!browser) return;
+
+  // add to database
   if (newEvent.date.allDay) {
     newEvent.date.start.setHours(0, 0, 0, 0);
     newEvent.date.end.setHours(0, 0, 0, 0);
@@ -273,20 +495,27 @@ export const createEvent = async (newEvent: EventModel): Promise<void> => {
 
   const formData = getEventFormData(newEvent);
 
-  const response = await fetch(`/api/calendars/${newEvent.calendar}/events`, { method: "PUT", body: formData });
-  if (response.ok) {
-    const json = await response.json();
-    newEvent.id = json.id;
+  const json = await fetchJson(`/api/calendars/${newEvent.calendar}/events`, { method: "PUT", body: formData }).catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to create event: ${err.message}`
+    );
+    throw err;
+  });
 
-    calendarEvents.set(newEvent.calendar, new Set([...calendarEvents.get(newEvent.calendar) || [], newEvent]));
-    compileEvents();
-  } else {
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
+  newEvent.id = json.id;
+
+  // add to cache
+  for (const month of determineEventMonths(newEvent)) addEventToCache(newEvent, month);
+
+  // add to display
+  if (isCalendarVisible(newEvent.calendar) && newEvent.date.start <= eventsRangeEnd && newEvent.date.end >= eventsRangeStart) events.update((events) => events.concat(newEvent));
 };
 
 export const editEvent = async (modifiedEvent: EventModel): Promise<void> => {
+  if (!browser) return;
+
+  // update in database
   if (modifiedEvent.date.allDay) {
     modifiedEvent.date.start.setHours(0, 0, 0, 0);
     modifiedEvent.date.end.setHours(0, 0, 0, 0);
@@ -294,36 +523,60 @@ export const editEvent = async (modifiedEvent: EventModel): Promise<void> => {
 
   const formData = getEventFormData(modifiedEvent);
 
-  const response = await fetch(`/api/events/${modifiedEvent.id}`, { method: "PATCH", body: formData });
-  if (response.ok) {
-    calendarEvents.set(modifiedEvent.calendar, new Set([...calendarEvents.get(modifiedEvent.calendar) || []].map((event) => event.id === modifiedEvent.id ? modifiedEvent : event)));
-    compileEvents();
-  } else {
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
+  return fetchResponse(`/api/events/${modifiedEvent.id}`, { method: "PATCH", body: formData })
+    .then(() => {
+        // update in cache
+        const previousMonths = determineEventMonths(eventsMap.get(modifiedEvent.id)!);
+        const currentMonths = determineEventMonths(modifiedEvent);
+        eventsMap.set(modifiedEvent.id, modifiedEvent);
+
+        for (const month of previousMonths) {
+          if (!currentMonths.includes(month)) {
+            removeEventFromCache(modifiedEvent, month);
+          }
+        }
+
+        for (const month of currentMonths) {
+          if (!previousMonths.includes(month)) {
+            addEventToCache(modifiedEvent, month);
+          }
+        }
+
+        // update on display
+        if (modifiedEvent.date.start <= eventsRangeEnd && modifiedEvent.date.end >= eventsRangeStart) {
+          events.update((events) => events.map((event) => event.id === modifiedEvent.id ? modifiedEvent : event));
+        } else {
+          events.update((events) => events.filter((event) => event.id !== modifiedEvent.id));
+        }
+    })
+    .catch((err) => {
+      queueNotification(
+        "failure",
+        `Failed to edit event: ${err.message}`
+      );
+      throw err;
+    });
 }
 
 export const deleteEvent = async (id: string): Promise<void> => {
-  const response = await fetch(`/api/events/${id}`, { method: "DELETE" });
-  if (response.ok) {
-    const event = eventsMap.get(id);
-    const calendarId = event?.calendar;
-    if (calendarId) {
-      calendarEvents.set(calendarId, new Set([...calendarEvents.get(calendarId) || []].filter((event) => event.id !== id)));
-      compileEvents();
-    }
-  } else {
-    const json = await response.json();
-    throw new Error(json ? json.error : "Could not contact the server");
-  }
-}
+  if (!browser) return;
 
-export const recalculateEventVisibility = () => {
-  compileEvents();
-}
+  // remove from database
+  await fetchResponse(`/api/events/${id}`, { method: "DELETE" }).catch((err) => {
+    queueNotification(
+      "failure",
+      `Failed to delete event: ${err.message}`
+    );
+    throw err;
+  });
 
-hiddenCalendars.subscribe(() => {
-  if (calendarEvents.size === 0) return;
-  recalculateEventVisibility();
-});
+  const event = eventsMap.get(id);
+  if (!event) return;
+
+  // remove from cache
+  const months = determineEventMonths(event);
+  for (const month of months) removeEventFromCache(event, month);
+
+  // remove from display
+  events.update((events) => events.filter((event) => event.id !== id));
+}

--- a/frontend/src/lib/client/repository.ts
+++ b/frontend/src/lib/client/repository.ts
@@ -583,6 +583,7 @@ export const createEvent = async (newEvent: EventModel): Promise<void> => {
   newEvent.id = json.id;
 
   // add to cache
+  eventsMap.set(newEvent.id, newEvent);
   for (const month of determineEventMonths(newEvent)) addEventToCache(newEvent, month);
 
   // add to display
@@ -650,6 +651,7 @@ export const deleteEvent = async (id: string): Promise<void> => {
 
   const event = eventsMap.get(id);
   if (!event) return;
+  eventsMap.delete(id);
 
   // remove from cache
   const months = determineEventMonths(event);

--- a/frontend/src/lib/common/misc.ts
+++ b/frontend/src/lib/common/misc.ts
@@ -1,0 +1,10 @@
+export async function atLeastOnePromise<T>(promises: Promise<T>[]): Promise<T[]> {
+    const results = await Promise.allSettled(promises);
+
+    const fulfilled = results.filter(result => result.status === 'fulfilled') as PromiseFulfilledResult<T>[];
+    if (fulfilled.length === 0 && results.length > 0) {
+        throw "All promises failed";
+    }
+
+    return fulfilled.map(result => result.value);
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -21,6 +21,9 @@
 
   import { setContext, untrack } from "svelte";
 
+  /* Constants */
+  let autoRefreshInterval = 1000 * 60; // 1 minute
+
   /* View */
   let view: "month" | "week" | "day" = $state("month");
 
@@ -103,8 +106,8 @@
     });
   })();
 
+  let spooledRefresh: ReturnType<typeof setTimeout>;
   function refresh(date: Date, force = false) {
-    console.log("REFRESH");
     sessionStorage.setItem("selectedDate", date.toString());
 
     const rangeStart = new Date(date);
@@ -127,6 +130,11 @@
     }
 
     getAllEvents(rangeStart, rangeEnd, force);
+
+    clearTimeout(spooledRefresh);
+    spooledRefresh = setTimeout(() => {
+      getAllEvents(rangeStart, rangeEnd);
+    }, autoRefreshInterval);
   }
 
   function forceRefresh() {
@@ -138,14 +146,10 @@
     ((date: Date, loaded: boolean) => {
       untrack(() => {
         if (!browser) return;
-        console.log("A")
         if (!loaded) {
           getRangeFromStorage();
-          console.log("B")
           return;
         }
-        console.log("C")
-        refresh(date);
       });
     })(date, pageLoaded);
   });

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -20,6 +20,7 @@
   import { queueNotification } from "$lib/client/notifications";
 
   import { setContext, untrack } from "svelte";
+  import Spinner from "../components/decoration/Spinner.svelte";
 
   /* View */
   let view: "month" | "week" | "day" = $state("month");
@@ -216,16 +217,16 @@
   <main>
     <div class="toprow">
       <MonthSelection bind:date granularity={view} />
-        <SelectButtons
-          name="layout"
-          compact={true}
-          bind:value={view}
-          options={[
-            { value: "day", name: "Day"},
-            { value: "week", name: "Week"},
-            { value: "month", name: "Month"},
-          ]}
-        />
+      <SelectButtons
+        name="layout"
+        compact={true}
+        bind:value={view}
+        options={[
+          { value: "day", name: "Day"},
+          { value: "week", name: "Week"},
+          { value: "month", name: "Month"},
+        ]}
+      />
     </div>
       <Calendar
         date={date}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -12,7 +12,7 @@
   import SourceModal from "../components/modals/SourceModal.svelte";
   import Title from "../components/layout/Title.svelte";
 
-  import { afterNavigate } from "$app/navigation";
+  import { afterNavigate, beforeNavigate } from "$app/navigation";
   import { browser } from "$app/environment";
 
   import { NoOp } from "$lib/client/placeholders";
@@ -39,17 +39,18 @@
   let date = $state(today);
 
   function getRangeFromStorage() {
+    console.log("HI");
     const storedDate = browser ? sessionStorage.getItem("selectedDate") : null;
     date = storedDate === null ? today : new Date(storedDate);
-  }
-
-  if (browser) {
-    getRangeFromStorage();
     loaded = true;
   }
 
   afterNavigate(() => {
     getRangeFromStorage();
+  });
+
+  beforeNavigate(() => {
+    loaded = false;
   });
 
   (async () => {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -39,7 +39,6 @@
   let date = $state(today);
 
   function getRangeFromStorage() {
-    console.log("HI");
     const storedDate = browser ? sessionStorage.getItem("selectedDate") : null;
     date = storedDate === null ? today : new Date(storedDate);
     loaded = true;

--- a/frontend/src/styles/animations.scss
+++ b/frontend/src/styles/animations.scss
@@ -10,6 +10,15 @@
   }
 }
 
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
 @keyframes zoom {
   from {
     transform: scale(0.95);

--- a/frontend/src/types/misc.d.ts
+++ b/frontend/src/types/misc.d.ts
@@ -14,3 +14,8 @@ type Validity = {
 }
 
 type InputValidation = (value: string) => Validity;
+
+type CacheEntry<T> = {
+  date: Date;
+  value: T | null;
+}

--- a/frontend/src/types/misc.d.ts
+++ b/frontend/src/types/misc.d.ts
@@ -16,6 +16,6 @@ type Validity = {
 type InputValidation = (value: string) => Validity;
 
 type CacheEntry<T> = {
-  date: Date;
+  date: number;
   value: T | null;
 }


### PR DESCRIPTION
Revamp data fetching in the frontend:
- Month-granular caching
- Minimize amount of sent out requests
- Local storage integration

I'm not suuuuper happy with this approach, but I wasn't happy with the previous one later.
Absolutely terrible asymptotic complexity, but I'd be surprised if someone actually reached enough events to see huge performance issues. Might (should) revisit later anyway.

Solves vikunja 102, 74, 79, 98

Also added:
- Loading indicators
- Manual refresh button
- Automatic refresh every minute (though it does not invalidate cache, so "true" automatic reload only happens every 10 minutes)

Also solves vikunja 61, 105