### PR TITLE
Popover Notifications

### DIFF
--- a/frontend/src/components/interactive/Notification.svelte
+++ b/frontend/src/components/interactive/Notification.svelte
@@ -13,8 +13,11 @@
 
   let isNew = $state(true);
   setTimeout(() => {
+    popover.showPopover();
     isNew = false;
   }, 0);
+
+  let popover: HTMLElement;
 </script>
 
 <style lang="scss">
@@ -23,9 +26,13 @@
   @import "../../styles/dimensions.scss";
 
   div.wrapper {
-    bottom: 100%;
-    right: 0;
-    width: 100%;
+    background-color: transparent;
+    outline: none;
+    border: none;
+    top: calc(100% - $gapSmaller);
+    left: calc(100% - $notificationWidth - $gapSmaller);
+    width: $notificationWidth;
+    // previously (before popover) instead of the above: bottom: 0, right: 0, no -50% subtraction in the style attribute down below
     position: absolute;
     padding-top: $gapSmaller;
     transition: all $cubic $animationSpeedSlow; 
@@ -75,8 +82,10 @@
 <div
   class="wrapper"
   class:disappear={notification.disappear}
-  style="transform: translateY({isNew ? "100%" : `${shift}px`});"
+  style="transform: translateY({isNew ? "100%" : `calc(${shift}px - 50%)`});"
+  popover="manual"
   bind:clientHeight={height}
+  bind:this={popover}
 >
 <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -68,7 +68,7 @@
     right: 0;
     bottom: 0;
     margin: $gapSmaller;
-    width: 15em;
+    width: $notificationWidth;
   }
 </style>
 

--- a/frontend/src/styles/dimensions.scss
+++ b/frontend/src/styles/dimensions.scss
@@ -25,3 +25,6 @@ $blur: 0.15em;
 $borderWidth: .1em;
 $underlineWidth: .15em;
 $barFocusIndicatorWidth: .3em;
+
+/* Notifications */
+$notificationWidth: 15em;


### PR DESCRIPTION
Attempts to solve no.32

Move notifications to the top layer using the new popover interface.

Remaining issues with this approach:
- The body briefly gets overflow during the animation that I can't seem to be able to hide.
- When you open yet another dialog, it still appears over the notifications.
- Hovering over the notification while a dialog is open does not change the cursor.
- Clicking the notification while a dialog is open will close the dialog instead of closing the notification.

Alternate route:
Abandon dialogs and popovers and implement their functionality myself.